### PR TITLE
Update to do AcquireTokenSilent first

### DIFF
--- a/MSALiOS/Base.lproj/Main.storyboard
+++ b/MSALiOS/Base.lproj/Main.storyboard
@@ -53,14 +53,6 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9u4-b8-vmX">
-                                <rect key="frame" x="156" y="220" width="48" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Logout"/>
-                                <connections>
-                                    <action selector="signoutButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kZT-P8-0Zy"/>
-                                </connections>
-                            </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5nx-eD-Bm8">
                                 <rect key="frame" x="101" y="138" width="158" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -69,12 +61,12 @@
                                     <action selector="callGraphApi:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1ig-Iv-TEd"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xMn-7k-qhB">
-                                <rect key="frame" x="131" y="176" width="98" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9u4-b8-vmX">
+                                <rect key="frame" x="163" y="182" width="48" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Refresh Token"/>
+                                <state key="normal" title="Logout"/>
                                 <connections>
-                                    <action selector="silentRefreshButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="slZ-ue-3rh"/>
+                                    <action selector="signoutButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kZT-P8-0Zy"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -84,7 +76,6 @@
                         <outlet property="callGraphApiButton" destination="5nx-eD-Bm8" id="ORd-Oa-aJm"/>
                         <outlet property="loggingText" destination="qXW-2z-J7K" id="uqO-Yw-AsK"/>
                         <outlet property="signoutButton" destination="9u4-b8-vmX" id="OCh-qk-ldv"/>
-                        <outlet property="silentRefreshButton" destination="xMn-7k-qhB" id="5qr-mj-3Yo"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/MSALiOS/ViewController.swift
+++ b/MSALiOS/ViewController.swift
@@ -63,7 +63,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
         
         if  try self.applicationContext.users().isEmpty {
             throw NSError.init(domain: "MSALErrorDomain", code: MSALErrorCode.interactionRequired.rawValue, userInfo: nil)
-        }
+        } else {
         
         /**
          
@@ -93,7 +93,12 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
 
                 }
             }
+        }
     }  catch let error as NSError {
+        
+        // interactionRequired means we need to ask the user to sign-in. This usually happens
+        // when the user's Refresh Token is expired or if the user has changed their password
+        // among other possible reasons.
         
         if error.code == MSALErrorCode.interactionRequired.rawValue {
             
@@ -112,6 +117,8 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
         }
         
     } catch {
+        
+        // This is the catch all error.
         
         self.loggingText.text = "Unable to acquire token. Got error: \(error)"
         


### PR DESCRIPTION
Updated the code to do AcquireTokenSilent() first and then AcquireToken() if that fails. This is the pattern that .Net uses and we've been requested to use as well.

[The pattern in .Net requires an `interactionRequired` MSALError to be thrown if the User object is nil](https://github.com/Azure-Samples/active-directory-dotnet-native-uwp-v2/blob/master/active-directory-dotnet-native-uwp-v2/MainPage.xaml.cs#L50), which doesn't happen in iOS library currently. To get around this for now I throw my own `MSALError` with `ErrorCode.interactionRequired`